### PR TITLE
Update templates + HTML inline style support

### DIFF
--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "Cargo.toml"
+      - "licensing/about.hbs"
+      - "licensing/about.toml"
       - ".github/workflows/licensing.yml"
 
 permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ lto = true
 actix-web = { version = "4.0.0-rc.3", features = ["compress-brotli", "compress-gzip"] }
 base64 = "0.13.0"
 bytes = "1.1.0"
-clap = { version = "3.0.12", features = ["derive", "env"] }
+clap = { version = "3.1.0", features = ["derive", "env"] }
 fern = "0.6.0"
 futures-util = "0.3.21"
 hex = "0.4.3"
-hmac-sha256 = "1.1.1"
+hmac-sha256 = "1.1.2"
 log = "0.4.14"
-lol_html = "0.3.0"
+lol_html = "0.3.1"
 markup = "0.12.5"
 mime = "0.3.16"
 once_cell = "1.9.0"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ searproxy [OPTIONS] --hmac-secret <HMAC_SECRET> --listen <LISTEN_ADDRESS>
 * `HTTP_PROXY` - HTTP(s) / SOCKS5 proxy for outgoing HTTP(s) requests
 * `SEARPROXY_REQUEST_TIMEOUT` - Timeout in seconds to wait for a request to complete (default: 5s)
 
-## Third party licenses
+## Open source licenses
 
-A list of licenses for the projects used can be found
+A list of licenses for the projects used in SearProxy can be found
 here: [friedemannsommer.github.io/searproxy/licenses.html](https://friedemannsommer.github.io/searproxy/licenses.html).
+
+This product includes software developed by the OpenSSL Project for use in the OpenSSL
+Toolkit. ([www.openssl.org](https://www.openssl.org/))

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,7 @@ allow = [
     "Apache-2.0",
     "MPL-2.0"
 ]
-copyleft = "allow"
+copyleft = "deny"
 allow-osi-fsf-free = "either"
 default = "deny"
 # [between 0.0 and 1.0].

--- a/licensing/about.hbs
+++ b/licensing/about.hbs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>

--- a/src/assets/header.css
+++ b/src/assets/header.css
@@ -1,6 +1,7 @@
 body > div.__sp_header {
     background: #000;
     border: none;
+    box-sizing: border-box;
     height: auto;
     left: 0;
     margin: 0;
@@ -8,9 +9,10 @@ body > div.__sp_header {
     position: relative;
     right: 0;
     top: 0;
-    /* subtract (left + right) padding */
-    width: calc(100% - 8px);
+    width: 100%;
     z-index: 2147483647 !important;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
 }
 
 body > div.__sp_header:after {
@@ -23,12 +25,24 @@ body > div.__sp_header > h1 {
     background: #000;
     color: #fff;
     float: left;
-    font-family: "Open Sans", "Garamond", "Georgia", sans-serif;
-    font-size: 14px;
     font-weight: bold;
-    line-height: 20px;
+    height: auto;
     margin: 0;
     padding: 0;
+    width: auto;
+}
+
+body > div.__sp_header > h1 > a, body > div.__sp_header > h1 > a:hover, body > div.__sp_header > h1 > a:active, body > div.__sp_header > h1 > a:focus, body > div.__sp_header > h1 > a:visited {
+    background: #000;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    display: inline;
+    font-family: "Open Sans", "Garamond", "Georgia", sans-serif;
+    font-size: 20px;
+    font-weight: bold;
+    line-height: 30px;
+    text-decoration: none;
 }
 
 body > div.__sp_header > p {
@@ -37,21 +51,24 @@ body > div.__sp_header > p {
     display: block;
     float: right;
     font-family: "Open Sans", "Garamond", "Georgia", sans-serif;
-    font-size: 14px;
+    font-size: 20px;
     font-weight: normal;
-    line-height: 20px;
+    height: auto;
+    line-height: 30px;
     margin: 0;
     padding: 0;
+    width: auto;
 }
 
-body > div.__sp_header > p > a {
+body > div.__sp_header > p > a, body > div.__sp_header > p > a:hover, body > div.__sp_header > p > a:active, body > div.__sp_header > p > a:focus, body > div.__sp_header > p > a:visited {
     background: #000;
+    border: none;
     cursor: pointer;
     color: #fff;
     display: inline;
     font-family: "Open Sans", "Garamond", "Georgia", sans-serif;
-    font-size: 14px;
-    font-weight: bold;
-    line-height: 20px;
+    font-size: 20px;
+    font-weight: normal;
+    line-height: 30px;
     text-decoration: underline;
 }

--- a/src/lib/rewrite_html.rs
+++ b/src/lib/rewrite_html.rs
@@ -1,12 +1,22 @@
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
-use lol_html::html_content::Element;
+use lol_html::html_content::{Element, EndTag, TextChunk};
 
+use crate::lib::rewrite_css::CssRewrite;
 use crate::lib::rewrite_url::rewrite_url;
 
-pub struct HtmlRewrite<'url> {
+type CssRewriteRef = Rc<RefCell<Option<CssRewrite>>>;
+type StyleHashList = Rc<RefCell<Vec<String>>>;
+
+pub struct HtmlRewrite<'html> {
     output: Rc<RefCell<Vec<u8>>>,
-    rewriter: lol_html::HtmlRewriter<'url, Box<dyn FnMut(&[u8])>>,
+    rewriter: lol_html::HtmlRewriter<'html, Box<dyn FnMut(&[u8])>>,
+    style_hashes: StyleHashList,
+}
+
+pub struct HtmlRewriteResult {
+    pub html: Vec<u8>,
+    pub style_hashes: Vec<String>,
 }
 
 static IMG_SRCSET_REGEX: once_cell::sync::Lazy<regex::Regex> = once_cell::sync::Lazy::new(|| {
@@ -19,7 +29,6 @@ static ALLOWED_ATTRIBUTES: once_cell::sync::Lazy<HashSet<&'static str>> =
         HashSet::from([
             "abbr",
             "accesskey",
-            "align",
             "align",
             "alt",
             "as",
@@ -43,7 +52,6 @@ static ALLOWED_ATTRIBUTES: once_cell::sync::Lazy<HashSet<&'static str>> =
             "lang",
             "loading",
             "media",
-            "media",
             "method",
             "name",
             "nowrap",
@@ -66,9 +74,11 @@ static ALLOWED_ATTRIBUTES: once_cell::sync::Lazy<HashSet<&'static str>> =
         ])
     });
 
-impl<'url> HtmlRewrite<'url> {
-    pub fn new(url: &'url url::Url) -> Self {
+impl<'html> HtmlRewrite<'html> {
+    pub fn new(url: Rc<url::Url>) -> Self {
         let output = Rc::new(RefCell::new(Vec::<u8>::new()));
+        let css_rewriter: CssRewriteRef = Rc::new(RefCell::new(None));
+        let style_hashes: StyleHashList = Rc::new(RefCell::new(Vec::<String>::new()));
 
         Self {
             output: output.clone(),
@@ -82,11 +92,20 @@ impl<'url> HtmlRewrite<'url> {
                         lol_html::element!("script", Self::remove_element),
                         lol_html::element!("svg", Self::remove_element),
                         lol_html::element!("*", Self::remove_disallowed_attributes),
-                        lol_html::element!("*[href]", Self::transform_href(url)),
-                        lol_html::element!("*[src]", Self::transform_src(url)),
+                        lol_html::element!("*[href]", Self::transform_href(url.clone())),
+                        lol_html::element!("*[src]", Self::transform_src(url.clone())),
+                        lol_html::element!("img[srcset]", Self::transform_srcset(url.clone())),
+                        lol_html::element!(
+                            "style",
+                            Self::transform_style(
+                                url.clone(),
+                                css_rewriter.clone(),
+                                style_hashes.clone()
+                            )
+                        ),
+                        lol_html::text!("style", Self::write_style(css_rewriter)),
                         lol_html::element!("body", Self::append_proxy_header(url)),
                         lol_html::element!("head", Self::append_proxy_styles),
-                        lol_html::element!("img[srcset]", Self::transform_srcset(url)),
                     ],
                     ..lol_html::Settings::default()
                 },
@@ -94,6 +113,7 @@ impl<'url> HtmlRewrite<'url> {
                     output.borrow_mut().extend_from_slice(chunk);
                 }),
             ),
+            style_hashes,
         }
     }
 
@@ -101,19 +121,22 @@ impl<'url> HtmlRewrite<'url> {
         self.rewriter.write(data)
     }
 
-    pub fn end(self) -> Result<Vec<u8>, lol_html::errors::RewritingError> {
+    pub fn end(self) -> Result<HtmlRewriteResult, lol_html::errors::RewritingError> {
         self.rewriter.end()?;
 
-        Ok(self.output.take())
+        Ok(HtmlRewriteResult {
+            html: self.output.take(),
+            style_hashes: self.style_hashes.take(),
+        })
     }
 
     fn transform_src(
-        base_url: &'_ url::Url,
-    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + '_ {
-        |element| {
+        base_url: Rc<url::Url>,
+    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'html {
+        move |element| {
             element.set_attribute(
                 "src",
-                &rewrite_url(base_url, &element.get_attribute("src").unwrap())?,
+                &rewrite_url(base_url.as_ref(), &element.get_attribute("src").unwrap())?,
             )?;
 
             Ok(())
@@ -121,16 +144,16 @@ impl<'url> HtmlRewrite<'url> {
     }
 
     fn transform_srcset(
-        base_url: &'_ url::Url,
-    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + '_ {
-        |element| {
+        base_url: Rc<url::Url>,
+    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'html {
+        move |element| {
             let src_set_values = element.get_attribute("srcset").unwrap();
             let mut output = String::with_capacity(src_set_values.len());
             let mut offset = 0;
 
             for group in IMG_SRCSET_REGEX.captures_iter(&src_set_values) {
                 if let Some(matched_url) = group.name("url") {
-                    let proxy_url = rewrite_url(base_url, matched_url.as_str())?;
+                    let proxy_url = rewrite_url(base_url.as_ref(), matched_url.as_str())?;
 
                     output.push_str(&src_set_values[offset..matched_url.start()]);
                     output.push_str(&proxy_url);
@@ -146,25 +169,79 @@ impl<'url> HtmlRewrite<'url> {
     }
 
     fn transform_href(
-        base_url: &'_ url::Url,
-    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + '_ {
-        |element: &mut Element| {
+        base_url: Rc<url::Url>,
+    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'html {
+        move |element: &mut Element| {
             element.set_attribute(
                 "href",
-                &rewrite_url(base_url, &element.get_attribute("href").unwrap())?,
+                &rewrite_url(base_url.as_ref(), &element.get_attribute("href").unwrap())?,
             )?;
 
             Ok(())
         }
     }
 
+    fn transform_style(
+        base_url: Rc<url::Url>,
+        css_rewriter: CssRewriteRef,
+        style_hashes: StyleHashList,
+    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'html {
+        move |element: &mut Element| {
+            css_rewriter.replace(Some(CssRewrite::new(base_url.clone())));
+            element.on_end_tag(Self::flush_style(
+                css_rewriter.clone(),
+                style_hashes.clone(),
+            ))?;
+
+            Ok(())
+        }
+    }
+
+    fn flush_style(
+        css_rewriter: CssRewriteRef,
+        style_hashes: StyleHashList,
+    ) -> impl Fn(&mut EndTag) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'static
+    {
+        move |end| {
+            let current_css_rewriter = css_rewriter.replace(None);
+            let css_bytes = current_css_rewriter.unwrap().end()?;
+
+            style_hashes.borrow_mut().push(format!(
+                "'sha256-{}'",
+                base64::encode(hmac_sha256::Hash::hash(css_bytes.as_slice()))
+            ));
+
+            end.before(
+                std::str::from_utf8(&css_bytes)?,
+                lol_html::html_content::ContentType::Text,
+            );
+
+            Ok(())
+        }
+    }
+
+    fn write_style(
+        css_rewriter: CssRewriteRef,
+    ) -> impl FnMut(&mut TextChunk) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'html
+    {
+        move |text: &mut TextChunk| {
+            css_rewriter
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .write(text.as_str().as_bytes())?;
+            text.remove();
+            Ok(())
+        }
+    }
+
     fn append_proxy_header(
-        base_url: &'_ url::Url,
-    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + '_ {
-        |element: &mut Element| {
+        base_url: Rc<url::Url>,
+    ) -> impl Fn(&mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + 'html {
+        move |element: &mut Element| {
             element.prepend(
                 crate::templates::render_template_string(crate::templates::Template::Header(
-                    base_url.as_str(),
+                    base_url.clone(),
                 ))
                 .as_str(),
                 lol_html::html_content::ContentType::Html,
@@ -216,57 +293,63 @@ impl<'url> HtmlRewrite<'url> {
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use crate::lib::rewrite_html::HtmlRewrite;
 
     #[test]
     fn rewrite_a_href_relative_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<a href='/'>main</a>").unwrap();
 
-        assert_eq!(std::str::from_utf8( rewriter.end().unwrap().as_slice()).unwrap(), "<a href=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2F&mortyhash=85870232cac1676c4477f7cae4da7173ccee4002f32e89c16038547aa20175c0\">main</a>");
+        assert_eq!(std::str::from_utf8( rewriter.end().unwrap().html.as_slice()).unwrap(), "<a href=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2F&mortyhash=85870232cac1676c4477f7cae4da7173ccee4002f32e89c16038547aa20175c0\">main</a>");
     }
 
     #[test]
     fn rewrite_img_src_relative_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/").unwrap(),
+        ));
 
         rewriter.write(b"<img src='/logo.png'>").unwrap();
 
-        assert_eq!(std::str::from_utf8( rewriter.end().unwrap().as_slice()).unwrap(), "<img src=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2Flogo.png&mortyhash=2aa2717d139a63b3f3fc43fa862c8a73fc7814f1140b5279fc2758bc9d8cc1f9\">");
+        assert_eq!(std::str::from_utf8( rewriter.end().unwrap().html.as_slice()).unwrap(), "<img src=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2Flogo.png&mortyhash=2aa2717d139a63b3f3fc43fa862c8a73fc7814f1140b5279fc2758bc9d8cc1f9\">");
     }
 
     #[test]
     fn rewrite_iframe_src_relative_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/").unwrap(),
+        ));
 
         rewriter
             .write(b"<iframe src='/test.html'></iframe>")
             .unwrap();
 
-        assert_eq!(std::str::from_utf8( rewriter.end().unwrap().as_slice()).unwrap(), "<iframe src=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2Ftest.html&mortyhash=48b7184730b6c78c9b4231f70560f92bdc09188ab27871d9489a372b3b47a9e1\"></iframe>");
+        assert_eq!(std::str::from_utf8( rewriter.end().unwrap().html.as_slice()).unwrap(), "<iframe src=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2Ftest.html&mortyhash=48b7184730b6c78c9b4231f70560f92bdc09188ab27871d9489a372b3b47a9e1\"></iframe>");
     }
 
     #[test]
     fn rewrite_img_attributes_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/").unwrap(),
+        ));
 
         rewriter.write(b"<img class='image' onmouseover='javascript:console.log(this)' onerror='javascript:alert(\"failed\")'>").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             "<img class='image'>"
         );
     }
@@ -275,13 +358,14 @@ mod tests {
     fn rewrite_img_srcset_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/").unwrap(),
+        ));
 
         rewriter.write(b"<img srcset='header640.png 640w, header960.png 960w, header1024.png 1024w, header.png'>").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             "<img srcset=\"./?mortyurl=https%3A%2F%2Fwww.example.com%2Fheader640.png&mortyhash=bf2aa9174435adfc3616a7bbb7f34e42cc7935e34feb23e0f6001b3acf2ceee0 640w, ./?mortyurl=https%3A%2F%2Fwww.example.com%2Fheader960.png&mortyhash=197fbfa4294a326f377651d2297f8ed5bf45018210e8615c7ee5dd7fad7037ec 960w, ./?mortyurl=https%3A%2F%2Fwww.example.com%2Fheader1024.png&mortyhash=d056d2f2316e7d9a1be4f34d7b430af80a610a87dc7616ae6d8d3d27cd84aef1 1024w, ./?mortyurl=https%3A%2F%2Fwww.example.com%2Fheader.png&mortyhash=890ee860e875afc9c56d972f1f44d64b55d93aeaf73a7f24e1cd43fc5806a414\">"
         );
     }
@@ -290,15 +374,16 @@ mod tests {
     fn rewrite_iframe_attributes_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/").unwrap(),
+        ));
 
         rewriter
             .write(b"<iframe height='1' width='1' onclick='javascript:alert(1)'></iframe>")
             .unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             "<iframe height='1' width='1'></iframe>"
         );
     }
@@ -307,13 +392,14 @@ mod tests {
     fn remove_applet_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<applet />").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             ""
         );
     }
@@ -322,13 +408,14 @@ mod tests {
     fn remove_canvas_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<canvas />").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             ""
         );
     }
@@ -337,13 +424,14 @@ mod tests {
     fn remove_embed_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<embed />").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             ""
         );
     }
@@ -352,13 +440,14 @@ mod tests {
     fn remove_math_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<math />").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             ""
         );
     }
@@ -367,13 +456,14 @@ mod tests {
     fn remove_script_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<script />").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             ""
         );
     }
@@ -382,13 +472,14 @@ mod tests {
     fn remove_svg_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<svg />").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             ""
         );
     }
@@ -397,13 +488,14 @@ mod tests {
     fn rewrite_body_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<body><h1>Test</h1></body>").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             // this is pretty finicky... (and will break if the "header.html" formatting changes)
             "<body><div class=\"__sp_header\"><h1>SearProxy</h1><p>This is a proxified and sanitized version, visit <a href=\"https://www.example.com/index.html\" target=\"_self\" rel=\"noreferrer noopener\">original page</a>.</p></div><h1>Test</h1></body>"
         );
@@ -413,13 +505,14 @@ mod tests {
     fn rewrite_head_n_1() {
         crate::lib::test_setup_hmac();
 
-        let base_url = url::Url::parse("https://www.example.com/index.html").unwrap();
-        let mut rewriter = HtmlRewrite::new(&base_url);
+        let mut rewriter = HtmlRewrite::new(Rc::new(
+            url::Url::parse("https://www.example.com/index.html").unwrap(),
+        ));
 
         rewriter.write(b"<head><title>Test</title></head>").unwrap();
 
         assert_eq!(
-            std::str::from_utf8(rewriter.end().unwrap().as_slice()).unwrap(),
+            std::str::from_utf8(rewriter.end().unwrap().html.as_slice()).unwrap(),
             "<head><title>Test</title><link rel=\"stylesheet\" href=\"./header.css\"></head>"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 mod assets;
 mod lib;
 mod model;
@@ -18,7 +16,7 @@ fn main() {
 fn get_config() -> model::Config<'static, 'static> {
     use clap::Parser;
 
-    let args: model::CliArgs = model::CliArgs::parse();
+    let args: model::Cli = model::Cli::parse();
 
     model::Config {
         follow_redirect: args.follow_redirect,
@@ -33,6 +31,8 @@ fn get_config() -> model::Config<'static, 'static> {
 }
 
 fn parse_socket_listener(input: &str) -> model::SocketListener {
+    use std::str::FromStr;
+
     if let Ok(address) = std::net::SocketAddr::from_str(input) {
         model::SocketListener::Tcp(address)
     } else if let Ok(path) = std::path::PathBuf::from_str(input) {

--- a/src/model/cli.rs
+++ b/src/model/cli.rs
@@ -1,9 +1,27 @@
-use clap::Parser;
+const ABOUT_WITH_LICENSE: &str = "This is a SearX & SearXNG compatible web proxy which \
+excludes potentially malicious HTML tags. It also rewrites links to external resources \
+to prevent leaks.
 
-/// A SearX[NG] compatible web content sanitizer proxy
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
-pub struct Args {
+This program is free software: you can redistribute it and/or modify it under the terms \
+of the GNU Affero General Public License as published by the Free Software Foundation, \
+either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; \
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU Affero General Public License for more details:
+<https://www.gnu.org/licenses/agpl-3.0.txt>
+
+This product includes software developed by the OpenSSL Project for use in \
+the OpenSSL Toolkit. <https://www.openssl.org/>";
+
+/// A SearX[NG] compatible web content sanitizer proxy.
+/// This program comes with ABSOLUTELY NO WARRANTY;
+/// This is free software, and you are welcome to redistribute it under certain conditions;
+/// type `--help` for more details.
+#[derive(clap::Parser, Debug)]
+#[clap(version, about, long_about = Some(ABOUT_WITH_LICENSE))]
+pub struct Cli {
     /// Allow "Location" response header following.
     #[clap(short, long, env = "SEARPROXY_FOLLOW_REDIRECTS")]
     pub follow_redirect: bool,
@@ -29,4 +47,16 @@ pub struct Args {
         default_value_t = 5
     )]
     pub request_timeout: u8,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+
+        Cli::command().debug_assert()
+    }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,4 @@
-pub use cli::Args as CliArgs;
+pub use cli::Cli;
 pub use config::{Config, SocketListener};
 pub use index_http_query::HttpArgs as IndexHttpArgs;
 

--- a/src/server/lib/content_security_policy.rs
+++ b/src/server/lib/content_security_policy.rs
@@ -1,0 +1,16 @@
+use actix_web::http::header::HeaderValue;
+
+pub fn get_content_security_policy(style_hashes_opt: Option<Vec<String>>) -> HeaderValue {
+    let style_src_hashes = if let Some(style_hashes) = style_hashes_opt {
+        style_hashes.join(" ")
+    } else {
+        String::new()
+    };
+
+    HeaderValue::from_str(
+        format!(
+            "default-src 'none'; block-all-mixed-content; img-src data: 'self'; style-src 'self' {}; prefetch-src 'self'; media-src 'self'; frame-src 'self'; font-src 'self'; frame-ancestors 'self'",
+            style_src_hashes
+        ).as_str()
+    ).expect("unexpected non ASCII chars in header value")
+}

--- a/src/server/lib/mod.rs
+++ b/src/server/lib/mod.rs
@@ -1,3 +1,5 @@
+pub use content_security_policy::get_content_security_policy;
 pub use error_response::{get_error_response, ErrorMessage};
 
+mod content_security_policy;
 mod error_response;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,5 @@
+use crate::server::lib::get_content_security_policy;
+
 pub mod lib;
 mod routes;
 
@@ -71,7 +73,7 @@ fn get_default_headers_middleware() -> actix_web::middleware::DefaultHeaders {
     actix_web::middleware::DefaultHeaders::new()
         .add((
             actix_web::http::header::CONTENT_SECURITY_POLICY,
-            "default-src 'none'; block-all-mixed-content; img-src data: 'self'; style-src 'self'; prefetch-src 'self'; media-src 'self'; frame-src 'self'; font-src 'self'; frame-ancestors 'self'",
+            get_content_security_policy(None),
         ))
         .add((actix_web::http::header::REFERRER_POLICY, "no-referrer"))
         .add((actix_web::http::header::X_FRAME_OPTIONS, "SAMEORIGIN"))

--- a/src/server/routes/route_index.rs
+++ b/src/server/routes/route_index.rs
@@ -1,3 +1,5 @@
+use crate::server::lib::get_content_security_policy;
+
 static DEFAULT_LANGUAGE: actix_web::http::header::HeaderValue =
     actix_web::http::header::HeaderValue::from_static("en");
 
@@ -72,6 +74,13 @@ async fn fetch_url(
                 headers.insert(actix_web::http::header::CONTENT_DISPOSITION, value);
             }
 
+            if let Some(style_hashes) = client_res.style_hashes {
+                headers.insert(
+                    actix_web::http::header::CONTENT_SECURITY_POLICY,
+                    get_content_security_policy(Some(style_hashes)),
+                );
+            }
+
             if let Ok(value) =
                 actix_web::http::header::HeaderValue::from_str(client_res.content_type.as_ref())
             {
@@ -81,7 +90,7 @@ async fn fetch_url(
             response
         }
         Err(err) => {
-            log::error!("{:?}", err);
+            log::error!("fetch_validate_url: {:?}", err);
             crate::server::lib::get_error_response(err)
         }
     }

--- a/src/templates/base.rs
+++ b/src/templates/base.rs
@@ -26,13 +26,38 @@ markup::define! {
                     @content
                 }
                 footer {
-                    a["href" = "https://github.com/friedemannsommer/searproxy", "target" = "_blank", "rel" = "noopener noreferrer"] {
-                        "Source code"
+                    p {
+                        @blank_ref("https://github.com/friedemannsommer/searproxy", "Source code")
+                        " | "
+                        @blank_ref("https://friedemannsommer.github.io/searproxy/licenses.html", "Open source licenses")
+                    }
+                    p {
+                        "This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. ("
+                        @blank_ref("https://www.openssl.org/", "www.openssl.org")
+                        ")"
                     }
                 }
             }
         }
     }
+
+    ExternalLinkTemplate<'url, Content: markup::Render>(
+        url: &'url str,
+        content: Content
+    ) {
+        a["href" = url, "target" = "_blank", "rel" = "noopener noreferrer"] {
+            @content
+        }
+    }
 }
 
+#[inline]
+pub fn blank_ref<Content: markup::Render>(
+    url: &str,
+    content: Content,
+) -> ExternalLinkTemplate<Content> {
+    ExternalLinkTemplate { url, content }
+}
+
+pub use ExternalLinkTemplate as ExternalLink;
 pub use Layout as Base;

--- a/src/templates/error.rs
+++ b/src/templates/error.rs
@@ -1,4 +1,4 @@
-use crate::templates::base::Base;
+use crate::templates::base::{blank_ref, Base};
 
 pub fn error<'error_detail>(
     error_detail_opt: &'error_detail std::option::Option<crate::server::lib::ErrorMessage<'_, '_>>,
@@ -9,16 +9,17 @@ pub fn error<'error_detail>(
     Base {
         header: markup::new! {
             h2 {
-                "Request failed."
+                "Request failed"
             }
         },
         content: markup::new! {
             @ if let Some(error_detail) = &error_detail_opt {
                 h3 {
-                    @ error_detail.name.as_ref()
+                    "Reason: "
+                    @error_detail.name.as_ref()
                 }
                 p {
-                    @ error_detail.description.as_ref()
+                    @error_detail.description.as_ref()
                 }
             } else {
                 h3 {
@@ -26,9 +27,7 @@ pub fn error<'error_detail>(
                 }
                 p {
                     "Consider "
-                    a["href" = "https://github.com/friedemannsommer/searproxy/issues", "target" = "_blank", "rel" = "noopener noreferrer"] {
-                        "opening an issue"
-                    }
+                    @blank_ref("https://github.com/friedemannsommer/searproxy/issues", "opening an issue")
                     "."
                 }
             }

--- a/src/templates/header.rs
+++ b/src/templates/header.rs
@@ -1,16 +1,20 @@
 markup::define! {
-    HeaderTemplate<'url>(url: &'url str) {
+    HeaderTemplate(url: std::rc::Rc<url::Url>) {
         div.__sp_header {
             h1 {
-                "SearProxy"
+                @SelfRef { url: "./", content: "SearProxy" }
             }
             p {
                 "This is a proxified and sanitized version, visit "
-                a["href" = url, "target" = "_self", "rel" = "noreferrer noopener"] {
-                    "original page"
-                }
+                @SelfRef { url: url.as_str(), content: "original page" }
                 "."
             }
+        }
+    }
+
+    SelfRef<'url, Content: markup::Render>(url: &'url str, content: Content) {
+        a["href" = url, "target" = "_self", "rel" = "noreferrer noopener"] {
+            @content
         }
     }
 }

--- a/src/templates/index.rs
+++ b/src/templates/index.rs
@@ -5,8 +5,9 @@ pub fn index(
     Base {
         header: markup::new! {
             h2 {
-                "This is a SearX & SearXNG compatible web proxy which excludes potentially malicious HTML tags. It also rewrites links
-        to external resources to prevent leaks."
+                "This is a SearX & SearXNG compatible web proxy which excludes potentially malicious HTML tags."
+                br;
+                "It also rewrites links to external resources to prevent leaks."
             }
         },
         content: markup::new! {

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -3,9 +3,9 @@ mod error;
 mod header;
 mod index;
 
-pub enum Template<'error_name, 'error_description, 'url> {
+pub enum Template<'error_name, 'error_description> {
     Error(Option<crate::server::lib::ErrorMessage<'error_name, 'error_description>>),
-    Header(&'url str),
+    Header(std::rc::Rc<url::Url>),
     Index,
 }
 


### PR DESCRIPTION
* [added support for inline styles (HTML <style> element)](https://github.com/friedemannsommer/searproxy/commit/a3759333dd4046daf287af3dc414f1786a4907c1)
* [added doctype for license overview template](https://github.com/friedemannsommer/searproxy/commit/6b8d4dbb1451b284c3b982a9168a963ff19c8d2d)
* [updated licensing workflow to also run when template or settings have been changed](https://github.com/friedemannsommer/searproxy/commit/0d68d8102e61c069f2bab8621e4984c3b9c73d0b)
* [updated "header", "index", "error" templates](https://github.com/friedemannsommer/searproxy/commit/a3759333dd4046daf287af3dc414f1786a4907c1)
* [updated "header" styles](https://github.com/friedemannsommer/searproxy/commit/a3759333dd4046daf287af3dc414f1786a4907c1)