### PR TITLE
Routing: use "actix_web" macros

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -46,7 +46,7 @@ pub async fn start_http_service() {
                 crate::assets::HEADER_STYLESHEET,
                 "text/css"
             ))
-            .route("/", actix_web::web::get().to(routes::handle_index))
+            .service(routes::handle_index)
     })
     .backlog(4096)
     .shutdown_timeout(5);

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -1,3 +1,3 @@
 mod route_index;
 
-pub use route_index::handle_request as handle_index;
+pub use route_index::handle_get_request as handle_index;

--- a/src/server/routes/route_index.rs
+++ b/src/server/routes/route_index.rs
@@ -3,7 +3,8 @@ use crate::server::lib::get_content_security_policy;
 static DEFAULT_LANGUAGE: actix_web::http::header::HeaderValue =
     actix_web::http::header::HeaderValue::from_static("en");
 
-pub async fn handle_request(
+#[actix_web::get("/")]
+pub async fn handle_get_request(
     query: actix_web::web::Query<crate::model::IndexHttpArgs>,
     http_request: actix_web::web::HttpRequest,
 ) -> actix_web::HttpResponse {


### PR DESCRIPTION
* use `actix_web::get` (macro) for path declaration
* renamed `handle_request` to `handle_get_request`