### PR TITLE
GitHub Action CI separate rust caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           toolchain: stable
       - name: Rust cache
         uses: Swatinem/rust-cache@v1
+        with:
+          key: test
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -66,6 +68,8 @@ jobs:
           toolchain: stable
       - name: Rust cache
         uses: Swatinem/rust-cache@v1
+        with:
+          key: check
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -85,6 +89,8 @@ jobs:
           components: rustfmt
       - name: Rust cache
         uses: Swatinem/rust-cache@v1
+        with:
+          key: rustfmt
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -105,6 +111,8 @@ jobs:
           components: clippy
       - name: Rust cache
         uses: Swatinem/rust-cache@v1
+        with:
+          key: clippy
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Introduced separate cache keys for "Test", "Check", "Rustfmt", and "Clippy".