### PR TITLE
Support HTML entitiy encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,26 +10,27 @@ codegen-units = 1
 lto = true
 
 [dependencies]
-actix-web = { version = "4.0.0-rc.3", features = ["compress-brotli", "compress-gzip"] }
-base64 = "0.13.0"
-bytes = "1.1.0"
-clap = { version = "3.1.0", features = ["derive", "env"] }
-fern = "0.6.0"
-futures-util = "0.3.21"
-hex = "0.4.3"
-hmac-sha256 = "1.1.2"
-log = "0.4.14"
-lol_html = "0.3.1"
-markup = "0.12.5"
-mime = "0.3.16"
-once_cell = "1.9.0"
-regex = "1.5.4"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_qs = "0.8.5"
-thiserror = "1.0.30"
-url = "2.2.2"
+actix-web = { version = "=4.0.0-rc.3", features = ["compress-brotli", "compress-gzip"] }
+base64 = "=0.13.0"
+bytes = "=1.1.0"
+clap = { version = "=3.1.2", features = ["derive", "env"] }
+fern = "=0.6.0"
+futures-util = "=0.3.21"
+hex = "=0.4.3"
+hmac-sha256 = "=1.1.2"
+htmlentity = "=1.2.0"
+log = "=0.4.14"
+lol_html = "=0.3.1"
+markup = "=0.12.5"
+mime = "=0.3.16"
+once_cell = "=1.9.0"
+regex = "=1.5.4"
+serde = { version = "=1.0.136", features = ["derive"] }
+serde_qs = "=0.8.5"
+thiserror = "=1.0.30"
+url = "=2.2.2"
 
 [dependencies.reqwest]
-version = "0.11.9"
+version = "=0.11.9"
 default-features = false
 features = ["brotli", "socks", "gzip", "deflate", "stream", "rustls-tls", "trust-dns"]

--- a/src/lib/rewrite_css.rs
+++ b/src/lib/rewrite_css.rs
@@ -110,7 +110,13 @@ impl CssRewrite {
                         }
                         _ => {
                             self.output.extend_from_slice(
-                                self.rewrite_url(self.url_start, offset + index)?.as_bytes(),
+                                rewrite_url(
+                                    &self.base_url,
+                                    std::str::from_utf8(
+                                        &self.buffer[self.url_start..offset + index],
+                                    )?,
+                                )?
+                                .as_bytes(),
                             );
                             self.output.push(*byte);
                             self.match_state.next()
@@ -129,7 +135,13 @@ impl CssRewrite {
                         }
                         _ => {
                             self.output.extend_from_slice(
-                                self.rewrite_url(self.url_start, offset + index)?.as_bytes(),
+                                rewrite_url(
+                                    &self.base_url,
+                                    std::str::from_utf8(
+                                        &self.buffer[self.url_start..offset + index],
+                                    )?,
+                                )?
+                                .as_bytes(),
                             );
                             self.output.push(*byte);
                             self.match_state.next();
@@ -139,7 +151,11 @@ impl CssRewrite {
                 b')' if self.match_state.inside_brackets() => {
                     if self.match_state != MatchState::ClosingBracket {
                         self.output.extend_from_slice(
-                            self.rewrite_url(self.url_start, offset + index)?.as_bytes(),
+                            rewrite_url(
+                                &self.base_url,
+                                std::str::from_utf8(&self.buffer[self.url_start..offset + index])?,
+                            )?
+                            .as_bytes(),
                         );
                     }
 
@@ -178,13 +194,6 @@ impl CssRewrite {
         } else {
             Ok(())
         }
-    }
-
-    fn rewrite_url(&self, start: usize, end: usize) -> Result<String, RewriteCssError> {
-        Ok(rewrite_url(
-            &self.base_url,
-            std::str::from_utf8(&self.buffer[start..end])?,
-        )?)
     }
 }
 

--- a/src/lib/rewrite_html.rs
+++ b/src/lib/rewrite_html.rs
@@ -286,11 +286,10 @@ impl<'html> HtmlRewrite<'html> {
             if let Some(action) = element.get_attribute("action") {
                 element.set_attribute(
                     "action",
-                    rewrite_url(
+                    &rewrite_url(
                         base_url.as_ref(),
                         Self::html_entity_decode(action.trim()).as_str(),
-                    )?
-                    .as_str(),
+                    )?,
                 )?;
             }
 
@@ -433,10 +432,11 @@ impl<'html> HtmlRewrite<'html> {
     }
 
     fn html_entity_decode(value: &str) -> String {
-        htmlentity::entity::decode(value)
-            .as_slice()
-            .iter()
-            .collect::<String>()
+        let mut result = String::with_capacity(value.len());
+
+        htmlentity::entity::decode_to(value, &mut result);
+
+        result
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 mod assets;
 mod lib;
 mod model;
@@ -75,6 +77,7 @@ fn set_shared_values(config: model::Config<'static, 'static>) {
         panic!("Failed to set HMAC instance");
     }
 
+    let timeout = std::time::Duration::from_secs(config.request_timeout as u64);
     let mut request_client_builder = reqwest::Client::builder()
         .referer(false)
         .deflate(true)
@@ -88,12 +91,8 @@ fn set_shared_values(config: model::Config<'static, 'static>) {
         .trust_dns(true)
         .tcp_nodelay(true)
         .tcp_keepalive(None)
-        .timeout(std::time::Duration::from_secs(
-            config.request_timeout as u64,
-        ))
-        .connect_timeout(std::time::Duration::from_secs(
-            config.request_timeout as u64,
-        ))
+        .timeout(timeout)
+        .connect_timeout(timeout)
         .user_agent(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0",
         );

--- a/src/model/index_http_query.rs
+++ b/src/model/index_http_query.rs
@@ -1,5 +1,5 @@
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
-pub struct HttpArgs {
+pub struct IndexHttpArgs {
     #[serde(rename = "mortyurl")]
     pub url: Option<String>,
     #[serde(rename = "mortyhash")]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,6 +1,6 @@
 pub use cli::Cli;
 pub use config::{Config, SocketListener};
-pub use index_http_query::HttpArgs as IndexHttpArgs;
+pub use index_http_query::IndexHttpArgs;
 
 mod cli;
 mod config;


### PR DESCRIPTION
* added support for HTML entity encoding (using "[htmlentity](https://crates.io/crates/htmlentity)" crate to decode HTML entities)
* updated cargo config to pin crate versions
* updated "clap" crate (`3.1.0` => `3.1.2`)
* updated `rewrite_url` to use `std::borrow::Cow` as `Result` value