### PR TITLE
Refactor: HMAC + HTML + IMG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,13 @@ codegen-units = 1
 lto = true
 
 [dependencies]
-actix-web = { version = "=4.0.0-rc.3", features = ["compress-brotli", "compress-gzip"] }
 base64 = "=0.13.0"
 bytes = "=1.1.0"
 clap = { version = "=3.1.2", features = ["derive", "env"] }
 fern = "=0.6.0"
 futures-util = "=0.3.21"
 hex = "=0.4.3"
-hmac-sha256 = "=1.1.2"
+hmac = "=0.12.1"
 htmlentity = "=1.2.0"
 log = "=0.4.14"
 lol_html = "=0.3.1"
@@ -30,7 +29,17 @@ serde_qs = "=0.8.5"
 thiserror = "=1.0.30"
 url = "=2.2.2"
 
+[dependencies.actix-web]
+version = "4.0.1"
+default-features = false
+features = ["compress-brotli", "compress-gzip", "compress-zstd", "macros"]
+
 [dependencies.reqwest]
 version = "=0.11.9"
 default-features = false
 features = ["brotli", "socks", "gzip", "deflate", "stream", "rustls-tls", "trust-dns"]
+
+[dependencies.sha2]
+version = "=0.10.2"
+default-features = false
+features = ["asm", "std"]

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ searproxy [OPTIONS] --hmac-secret <HMAC_SECRET> --listen <LISTEN_ADDRESS>
 ## Options
 
 * `-f` / `--follow-redirect` - Allow "Location" response header following (default: false)
-* `-h` / `--help` - Print help information
 * `-l` / `--listen` - <IPv4 / IPv6>:port or socket to listen on
+* `--lazy-images` - Enable IMG element rewriting with "lazy" loading. (default: false)
 * `-p` / `--proxy-address` - HTTP(s) / SOCKS5 proxy for outgoing HTTP(s) requests
 * `-s` / `--hmac-secret` - Base64 encoded string to use as HMAC 256 secret
 * `-t` / `--request-timeout` - Timeout in seconds to wait for a request to complete (default: 5s)
 * `-v` / `--log-level` - Log level to use (default: WARN)
+* `-w` / `--worker-count` - Worker thread count for handling incoming HTTP requests (default: CPU core count)
+* `-h` / `--help` - Print help information
 * `-V` / `--version` - Print version information
 
 ## ENV options
@@ -28,9 +30,11 @@ searproxy [OPTIONS] --hmac-secret <HMAC_SECRET> --listen <LISTEN_ADDRESS>
 * `SEARPROXY_FOLLOW_REDIRECTS` - Allow "Location" response header following (default: false)
 * `SEARPROXY_HMAC_SECRET` - Base64 encoded string to use as HMAC 256 secret
 * `SEARPROXY_LISTEN` - <IPv4 / IPv6>:port or socket to listen on
+* `SEARPROXY_LAZY_IMAGES` - Enable IMG element rewriting with "lazy" loading. (default: false)
 * `SEARPROXY_LOG_LEVEL` - Log level to use (default: WARN)
 * `HTTP_PROXY` - HTTP(s) / SOCKS5 proxy for outgoing HTTP(s) requests
 * `SEARPROXY_REQUEST_TIMEOUT` - Timeout in seconds to wait for a request to complete (default: 5s)
+* `SEARPROXY_WORKER_COUNT` - Worker thread count for handling incoming HTTP requests (default: CPU core count)
 
 ## Open source licenses
 

--- a/src/lib/shared.rs
+++ b/src/lib/shared.rs
@@ -1,4 +1,5 @@
-pub static HMAC: once_cell::sync::OnceCell<hmac_sha256::HMAC> = once_cell::sync::OnceCell::new();
+pub static HMAC: once_cell::sync::OnceCell<hmac::Hmac<sha2::Sha256>> =
+    once_cell::sync::OnceCell::new();
 pub static REQUEST_CLIENT: once_cell::sync::OnceCell<reqwest::Client> =
     once_cell::sync::OnceCell::new();
 pub static GLOBAL_CONFIG: once_cell::sync::OnceCell<crate::model::Config> =
@@ -12,7 +13,12 @@ pub static HEADER_VALUE_CONTENT_HTML: once_cell::sync::Lazy<actix_web::http::hea
 
 #[cfg(test)]
 pub fn test_setup_hmac() {
-    if HMAC.set(hmac_sha256::HMAC::new(b"example")).is_err() {
+    use hmac::digest::KeyInit;
+
+    if HMAC
+        .set(hmac::Hmac::new_from_slice(b"example").unwrap())
+        .is_err()
+    {
         // silently ignore this, since it only `Err`s on successive calls
     }
 }

--- a/src/model/cli.rs
+++ b/src/model/cli.rs
@@ -24,10 +24,14 @@ the OpenSSL Toolkit. <https://www.openssl.org/>";
 pub struct Cli {
     /// Allow "Location" response header following.
     #[clap(short, long, env = "SEARPROXY_FOLLOW_REDIRECTS")]
-    pub follow_redirect: bool,
+    pub follow_redirects: bool,
     /// Base64 encoded string to use as HMAC 256 secret.
     #[clap(short = 's', long, env = "SEARPROXY_HMAC_SECRET")]
     pub hmac_secret: String,
+    /// Enable IMG element rewriting with "lazy" loading.
+    /// Since this can be used to measure the clients scroll position, it's disabled by default.
+    #[clap(long, env = "SEARPROXY_LAZY_IMAGES")]
+    pub lazy_images: bool,
     /// <IPv4 / IPv6>:port or socket to listen on.
     #[clap(short, long, env = "SEARPROXY_LISTEN")]
     pub listen: String,
@@ -47,6 +51,9 @@ pub struct Cli {
         default_value_t = 5
     )]
     pub request_timeout: u8,
+    /// Worker thread count for handling incoming HTTP requests.
+    #[clap(short = 'w', long, env = "SEARPROXY_WORKER_COUNT", default_value_t = 0)]
+    pub worker_count: u8,
 }
 
 #[cfg(test)]

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -8,10 +8,12 @@ pub enum SocketListener {
 
 #[derive(Debug)]
 pub struct Config<'secret, 'proxy> {
-    pub follow_redirect: bool,
+    pub follow_redirects: bool,
     pub hmac_secret: Cow<'secret, [u8]>,
+    pub lazy_images: bool,
     pub listen: SocketListener,
     pub log_level: log::LevelFilter,
     pub proxy_address: Option<Cow<'proxy, str>>,
     pub request_timeout: u8,
+    pub worker_count: u8,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,7 +8,7 @@ pub async fn start_http_service() {
     let config = crate::lib::GLOBAL_CONFIG
         .get()
         .expect("Global config is not initialized");
-    let http_server = actix_web::HttpServer::new(move || {
+    let mut http_server = actix_web::HttpServer::new(move || {
         actix_web::App::new()
             .wrap(actix_web::middleware::Compress::default())
             .wrap(actix_web::middleware::NormalizePath::new(
@@ -51,6 +51,10 @@ pub async fn start_http_service() {
     })
     .backlog(4096)
     .shutdown_timeout(5);
+
+    if config.worker_count != 0 {
+        http_server = http_server.workers(config.worker_count as usize);
+    }
 
     match match &config.listen {
         crate::model::SocketListener::Tcp(address) => http_server.bind(address),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,8 +14,11 @@ pub async fn start_http_service() {
             .wrap(actix_web::middleware::NormalizePath::new(
                 actix_web::middleware::TrailingSlash::Trim,
             ))
-            .wrap(actix_web::middleware::Logger::new("%a '%r' %s %T"))
             .wrap(get_default_headers_middleware())
+            .wrap(actix_web::middleware::Condition::new(
+                log::log_enabled!(log::Level::Info),
+                actix_web::middleware::Logger::new("%a '%r' %s %T"),
+            ))
             .service(crate::static_asset_route!(
                 "/favicon.ico",
                 crate::assets::FAVICON_ICO_FILE,

--- a/src/server/routes/index.rs
+++ b/src/server/routes/index.rs
@@ -6,7 +6,7 @@ use crate::{
 #[actix_web::get("/")]
 pub async fn handle_get_request(
     query: actix_web::web::Query<crate::model::IndexHttpArgs>,
-    http_request: actix_web::web::HttpRequest,
+    http_request: actix_web::HttpRequest,
 ) -> actix_web::HttpResponse {
     let response = get_base_response();
 
@@ -25,7 +25,7 @@ pub async fn handle_get_request(
 #[actix_web::post("/")]
 pub async fn handle_post_request(
     query: actix_web::web::Query<crate::model::IndexHttpArgs>,
-    http_request: actix_web::web::HttpRequest,
+    http_request: actix_web::HttpRequest,
     mut body: actix_web::web::Form<std::collections::HashMap<String, String>>,
 ) -> actix_web::HttpResponse {
     let response = get_base_response();


### PR DESCRIPTION
* Added `lazy_images` flag and `worker_count` option as CLI options
* Renamed `follow_redirect` to `follow_redirects`
* Replaced "[hmac-sha256](https://crates.io/crates/hmac-sha256)" with "[hmac](https://crates.io/crates/hmac)" and "[sha2](https://crates.io/crates/sha2)"
* Upgraded "[actix-web](https://crates.io/crates/actix-web)" to "[4.0.1](https://github.com/actix/actix-web/blob/542200cbc28bb46ea0949852734da0dfd35eaebb/actix-web/CHANGES.md#400---2022-02-25)"
* Added "sizes" as allowed attribute
* Updated IMG "srcset" processing to accept (invalid) "URL 100w 50h" format