### PR TITLE
Refactor redirect (3XX) implementation

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,4 +1,7 @@
-pub use client::{fetch_validate_url, BodyType, ClientError, FormRequest};
+pub use client::{
+    fetch_validate_url, BodyType, ClientError, ClientRedirect, ClientResponse, FetchResult,
+    FormRequest,
+};
 #[cfg(test)]
 pub use shared::test_setup_hmac;
 pub use shared::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,7 @@ fn set_shared_values(config: model::Config<'static, 'static>) {
         .deflate(true)
         .gzip(true)
         .brotli(true)
-        .redirect(if config.follow_redirects {
-            reqwest::redirect::Policy::limited(15)
-        } else {
-            reqwest::redirect::Policy::none()
-        })
+        .redirect(reqwest::redirect::Policy::none())
         .trust_dns(true)
         .tcp_nodelay(true)
         .tcp_keepalive(None)

--- a/src/server/lib/error_response.rs
+++ b/src/server/lib/error_response.rs
@@ -58,6 +58,10 @@ fn get_error_message(error_detail: ClientError) -> Option<ErrorMessage<'static, 
             name: Cow::Borrowed("Bad request"),
             description: Cow::Owned(error_detail.to_string()),
         }),
+        ClientError::RedirectWithoutLocation => Some(ErrorMessage {
+            name: Cow::Borrowed("Invalid redirect"),
+            description: Cow::Owned(error_detail.to_string()),
+        }),
         _ => None,
     }
 }

--- a/src/server/lib/fetch_url.rs
+++ b/src/server/lib/fetch_url.rs
@@ -1,45 +1,89 @@
-use crate::{lib::FormRequest, server::lib::get_content_security_policy};
+use actix_web::http::header::HeaderValue;
+
+use crate::{
+    lib::{fetch_validate_url, ClientRedirect, ClientResponse, FetchResult, FormRequest},
+    server::lib::get_content_security_policy,
+};
 
 pub async fn fetch_url(
-    mut response: actix_web::HttpResponse,
+    response: actix_web::HttpResponse,
     url: &str,
     hash: &str,
     languages: &str,
     request_body: Option<FormRequest>,
 ) -> actix_web::HttpResponse {
-    match crate::lib::fetch_validate_url(url, hash, languages, request_body).await {
-        Ok(client_res) => {
-            response = response.set_body(match client_res.body {
-                crate::lib::BodyType::Complete(bytes) => actix_web::body::BoxBody::new(bytes),
-                crate::lib::BodyType::Stream(stream) => {
-                    actix_web::body::BoxBody::new(actix_web::body::BodyStream::new(stream))
-                }
-            });
-
-            let headers = response.headers_mut();
-
-            if let Some(value) = client_res.content_disposition {
-                headers.insert(actix_web::http::header::CONTENT_DISPOSITION, value);
+    match fetch_validate_url(url, hash, languages, request_body).await {
+        Ok(fetch_result) => match fetch_result {
+            FetchResult::Response(client_res) => handle_client_response(response, client_res),
+            FetchResult::Redirect(client_redirect) => {
+                handle_client_redirect(response, client_redirect)
             }
-
-            if let Some(style_hashes) = client_res.style_hashes {
-                headers.insert(
-                    actix_web::http::header::CONTENT_SECURITY_POLICY,
-                    get_content_security_policy(Some(style_hashes)),
-                );
-            }
-
-            if let Ok(value) =
-                actix_web::http::header::HeaderValue::from_str(client_res.content_type.as_ref())
-            {
-                headers.insert(actix_web::http::header::CONTENT_TYPE, value);
-            }
-
-            response
-        }
+        },
         Err(err) => {
             log::error!("fetch_validate_url: {:?}", err);
             crate::server::lib::get_error_response(err)
         }
     }
+}
+
+fn handle_client_response(
+    mut response: actix_web::HttpResponse,
+    client_res: ClientResponse,
+) -> actix_web::HttpResponse {
+    response = response.set_body(match client_res.body {
+        crate::lib::BodyType::Complete(bytes) => actix_web::body::BoxBody::new(bytes),
+        crate::lib::BodyType::Stream(stream) => {
+            actix_web::body::BoxBody::new(actix_web::body::BodyStream::new(stream))
+        }
+    });
+
+    let headers = response.headers_mut();
+
+    if let Some(value) = client_res.content_disposition {
+        headers.insert(actix_web::http::header::CONTENT_DISPOSITION, value);
+    }
+
+    if let Some(style_hashes) = client_res.style_hashes {
+        headers.insert(
+            actix_web::http::header::CONTENT_SECURITY_POLICY,
+            get_content_security_policy(Some(style_hashes)),
+        );
+    }
+
+    if let Ok(value) = HeaderValue::from_str(client_res.content_type.as_ref()) {
+        headers.insert(actix_web::http::header::CONTENT_TYPE, value);
+    }
+
+    response
+}
+
+fn handle_client_redirect(
+    mut response: actix_web::HttpResponse,
+    client_redirect: ClientRedirect,
+) -> actix_web::HttpResponse {
+    let header_value_res = HeaderValue::try_from(client_redirect.internal_url.as_str());
+
+    if let Ok(header_value) = header_value_res {
+        if let Some(config) = crate::lib::GLOBAL_CONFIG.get() {
+            if config.follow_redirects {
+                response
+                    .headers_mut()
+                    .insert(actix_web::http::header::LOCATION, header_value);
+                *response.status_mut() = actix_web::http::StatusCode::TEMPORARY_REDIRECT;
+                return response;
+            }
+        }
+    }
+
+    response.headers_mut().insert(
+        actix_web::http::header::CONTENT_TYPE,
+        HeaderValue::from_static(mime::TEXT_HTML_UTF_8.as_ref()),
+    );
+    response = response.set_body(actix_web::body::BoxBody::new(
+        crate::templates::render_template_string(crate::templates::Template::Redirect(
+            client_redirect,
+        )),
+    ));
+
+    response
 }

--- a/src/server/routes/index.rs
+++ b/src/server/routes/index.rs
@@ -76,7 +76,7 @@ fn render_index(response: actix_web::HttpResponse) -> actix_web::HttpResponse {
 
     response_body.headers_mut().insert(
         actix_web::http::header::CONTENT_TYPE,
-        actix_web::http::header::HeaderValue::from_static("text/html"),
+        actix_web::http::header::HeaderValue::from_static(mime::TEXT_HTML_UTF_8.as_ref()),
     );
 
     response_body

--- a/src/templates/base.rs
+++ b/src/templates/base.rs
@@ -52,6 +52,15 @@ markup::define! {
             @content
         }
     }
+
+    InternalLinkTemplate<'url, Content:markup::Render>(
+        url: &'url str,
+        content: Content
+    ) {
+        a["href" = url, "target" = "_self", "rel" = "noreferrer noopener"] {
+            @content
+        }
+    }
 }
 
 #[inline]
@@ -60,4 +69,12 @@ pub fn blank_ref<Content: markup::Render>(
     content: Content,
 ) -> ExternalLinkTemplate<Content> {
     ExternalLinkTemplate { url, content }
+}
+
+#[inline]
+pub fn self_ref<Content: markup::Render>(
+    url: &str,
+    content: Content,
+) -> InternalLinkTemplate<Content> {
+    InternalLinkTemplate { url, content }
 }

--- a/src/templates/header.rs
+++ b/src/templates/header.rs
@@ -1,22 +1,18 @@
+pub use HeaderTemplate as Header;
+
+use crate::templates::base::self_ref;
+
 markup::define! {
     HeaderTemplate(url: std::rc::Rc<url::Url>) {
         div {
             h1 {
-                @SelfRef { url: "./", content: "SearProxy" }
+                @self_ref("./", "SearProxy")
             }
             p {
                 "This is a proxified and sanitized version, visit "
-                @SelfRef { url: url.as_str(), content: "original page" }
+                @self_ref(url.as_str(),  "original page")
                 "."
             }
         }
     }
-
-    SelfRef<'url, Content: markup::Render>(url: &'url str, content: Content) {
-        a["href" = url, "target" = "_self", "rel" = "noreferrer noopener"] {
-            @content
-        }
-    }
 }
-
-pub use HeaderTemplate as Header;

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -2,11 +2,13 @@ mod base;
 mod error;
 mod header;
 mod index;
+mod redirect;
 
 pub enum Template<'error_name, 'error_description> {
     Error(Option<crate::server::lib::ErrorMessage<'error_name, 'error_description>>),
     Header(std::rc::Rc<url::Url>),
     Index,
+    Redirect(crate::lib::ClientRedirect),
 }
 
 pub fn render_template_string(template: Template) -> String {
@@ -14,5 +16,6 @@ pub fn render_template_string(template: Template) -> String {
         Template::Error(error_detail) => error::error(&error_detail).to_string(),
         Template::Header(url) => header::Header { url }.to_string(),
         Template::Index => index::index().to_string(),
+        Template::Redirect(url) => redirect::redirect(url).to_string(),
     }
 }

--- a/src/templates/redirect.rs
+++ b/src/templates/redirect.rs
@@ -1,0 +1,21 @@
+use crate::templates::base::{self_ref, Base};
+
+pub fn redirect(
+    client_redirect: crate::lib::ClientRedirect,
+) -> Base<impl std::fmt::Display + markup::Render, impl std::fmt::Display + markup::Render> {
+    let status_code = client_redirect.status_code;
+
+    Base {
+        header: markup::new! {
+            h2 { "Server returned redirect" }
+            p {
+                "Status code:"
+                @status_code.as_str()
+            }
+        },
+        content: markup::new! {
+            h3 { "If you want to follow the returned URL, click the link below:" }
+            @self_ref(&client_redirect.internal_url, &client_redirect.external_url)
+        },
+    }
+}


### PR DESCRIPTION
Added a new implementation which will either return the redirect to the client (if `follow_redirects` is `true`) or render a splash page which includes the returned URL.